### PR TITLE
CPD-4198: Update base image to include java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 MAINTAINER Acquia Engineering <engineering@acquia.com>
 
 ARG RUBY_VERSION
 ENV RUBY_VERSION ${RUBY_VERSION:-2.5.1}
 
+# Install base system dependencies
 RUN set -xe \
-    # Install base system dependencies
     && yum install -y \
       autoconf \
       automake \
@@ -30,6 +30,7 @@ RUN set -xe \
       git \
       glibc-devel \
       glibc-headers \
+      java-1.8.0-openjdk \
       libffi-devel \
       libicu-devel \
       libtool \
@@ -43,16 +44,15 @@ RUN set -xe \
       systemd-devel \
       tar \
       which \
+    && yum clean all \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/*
 
-    # Install Ruby and Bundler
-    && gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
+# Install Ruby and Bundler
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
     && curl -sSL https://get.rvm.io | bash \
     && /bin/bash -l -c "rvm install ${RUBY_VERSION} \
       && rvm default ${RUBY_VERSION} \
-      && gem install bundler -v 1.14.6 \
-      && rvm cleanup all" \
+      && gem install bundler \
+      && rvm cleanup all" 
 
-  # Cleanup
-  && yum clean all \
-  && rm -rf /tmp/* \
-  && rm -rf /var/tmp/*


### PR DESCRIPTION
- Updates base image to include Java for the log processing pipeline.
- Updates ruby and bundler version to match acquia/cloud-database-api@2.35.0